### PR TITLE
extract data from entire cm returned by get_configmap

### DIFF
--- a/app.py
+++ b/app.py
@@ -38,8 +38,8 @@ def main():
     oc = OpenShift()
     cm = oc.get_configmap(configmap_id="mi-scheduler", namespace="thoth-test-core")
 
-    organizations = cm.get("organizations", "")
-    repositories = cm.get("repositories", "")
+    organizations = cm["data"].get("organizations", "")
+    repositories = cm["data"].get("repositories", "")
 
     gh = Github()
     repos = set()


### PR DESCRIPTION
extract data from entire cm returned by get_configmap
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## This introduces a breaking change

- [x] No

## Description

thoth-common get_configmap function returns entire configmap as dict, the data is to be extracted from the configmap.