### PR TITLE
Remove codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-*    @xtuchyna @goern @harshad16 @fridex


### PR DESCRIPTION
## Related Issues and Dependencies
`CODEOWNERS` no more used  (`OWNERS` used instead)