### PR TITLE
change overlay contextpath to zero-test

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -11,4 +11,4 @@ deploy:
   project-org: thoth-station
   project-name: thoth-application
   image-name: mi-scheduler
-  overlay-contextpath: mi-scheduler/overlays/test/imagestreamtag.yaml
+  overlay-contextpath: mi-scheduler/overlays/zero-test/imagestreamtag.yaml


### PR DESCRIPTION
Automatically update `mi-scheduler` with the newest tag on `zero-test`
/cc @harshad16 

## This introduces a breaking change

- [ ] Yes
- [X] No
