### PR TITLE
Fix/convert path to string

### DIFF
--- a/app.py
+++ b/app.py
@@ -61,8 +61,8 @@ class Schedule:
         self.checked_repos: Set[str] = set()
 
         deployment_name = os.environ["THOTH_DEPLOYMENT_NAME"]
-        self.kebechet_path = Path(f"{deployment_name}/{subdir}/thoth-sli-metrics/kebechet-update-manager/")
-        self.mi_path = Path(f"{deployment_name}/mi/{subdir}")
+        self.kebechet_path = str(Path(f"{deployment_name}/{subdir}/thoth-sli-metrics/kebechet-update-manager/"))
+        self.mi_path = str(Path(f"{deployment_name}/mi/{subdir}"))
 
         self._initialize_repositories_from_organizations()
         self._initialize_repositories_from_raw()

--- a/app.py
+++ b/app.py
@@ -46,10 +46,10 @@ class Schedule:
     def __init__(
         self,
         openshift: OpenShift,
+        subdir: str = "",
         github: Optional[Github] = None,
         organizations: List[str] = None,
         repositories: List[str] = None,
-        subdir: Optional[str] = None,
     ):
         """Initialize with github, orgs and repos optional."""
         self.gh = github

--- a/app.py
+++ b/app.py
@@ -46,10 +46,10 @@ class Schedule:
     def __init__(
         self,
         openshift: OpenShift,
-        subdir: str = "",
         github: Optional[Github] = None,
         organizations: List[str] = None,
         repositories: List[str] = None,
+        subdir: str = "",
     ):
         """Initialize with github, orgs and repos optional."""
         self.gh = github
@@ -156,12 +156,9 @@ def main(
     kebechet_analysis: Optional[bool],
     kebechet_merge: Optional[bool],
     gh_repo_analysis: Optional[bool],
-    subdir: Optional[str],
+    subdir: str = "",
 ):
     """MI-Scheduler entrypoint."""
-    if subdir is None:
-        subdir = ""
-
     gh = Github(login_or_token=GITHUB_ACCESS_TOKEN)
     oc = OpenShift()
 

--- a/app.py
+++ b/app.py
@@ -159,6 +159,9 @@ def main(
     subdir: Optional[str],
 ):
     """MI-Scheduler entrypoint."""
+    if subdir is None:
+        subdir = ""
+
     gh = Github(login_or_token=GITHUB_ACCESS_TOKEN)
     oc = OpenShift()
 

--- a/app.py
+++ b/app.py
@@ -38,6 +38,7 @@ _LOGGER = logging.getLogger(__title__)
 GITHUB_ACCESS_TOKEN = os.getenv("GITHUB_ACCESS_TOKEN")
 
 KEBECHET_ENTITIES = "PullRequest,Issue"
+KEBECHET_KNOWLEDGE_PATH = Path("thoth-sli-metrics").joinpath("kebechet-update-manager")
 
 
 class Schedule:
@@ -61,8 +62,8 @@ class Schedule:
         self.checked_repos: Set[str] = set()
 
         deployment_name = os.environ["THOTH_DEPLOYMENT_NAME"]
-        self.kebechet_path = str(Path(f"{deployment_name}/{subdir}/thoth-sli-metrics/kebechet-update-manager/"))
-        self.mi_path = str(Path(f"{deployment_name}/mi/{subdir}"))
+        self.kebechet_path = str(Path(deployment_name).joinpath(subdir).joinpath(KEBECHET_KNOWLEDGE_PATH))
+        self.mi_path = str(Path(deployment_name).joinpath("mi").joinpath(subdir))
 
         self._initialize_repositories_from_organizations()
         self._initialize_repositories_from_raw()

--- a/app.py
+++ b/app.py
@@ -40,6 +40,8 @@ GITHUB_ACCESS_TOKEN = os.getenv("GITHUB_ACCESS_TOKEN")
 KEBECHET_ENTITIES = "PullRequest,Issue"
 KEBECHET_KNOWLEDGE_PATH = Path("thoth-sli-metrics").joinpath("kebechet-update-manager")
 
+DEPLOYMENT_NAME = os.environ["THOTH_DEPLOYMENT_NAME"]
+
 
 class Schedule:
     """Schedule class which handles repository and organization checks and schedule methods."""
@@ -61,9 +63,8 @@ class Schedule:
 
         self.checked_repos: Set[str] = set()
 
-        deployment_name = os.environ["THOTH_DEPLOYMENT_NAME"]
-        self.kebechet_path = str(Path(deployment_name).joinpath(subdir).joinpath(KEBECHET_KNOWLEDGE_PATH))
-        self.mi_path = str(Path(deployment_name).joinpath("mi").joinpath(subdir))
+        self.kebechet_path = Path(DEPLOYMENT_NAME).joinpath(subdir).joinpath(KEBECHET_KNOWLEDGE_PATH).as_posix()
+        self.mi_path = Path(DEPLOYMENT_NAME).joinpath("mi").joinpath(subdir).as_posix()
 
         self._initialize_repositories_from_organizations()
         self._initialize_repositories_from_raw()


### PR DESCRIPTION
## Related Issues and Dependencies
Related to recent #167  and #156 
Seems like the subdir is still set to `None`, therefore adding explicit check for that and also converting the Path object to string (so that the types are compatible between the `mi-scheduler` and `common`).

## This introduces a breaking change

- [ ] Yes
- [X] No

/kind bug
