### PR TITLE
Get MI_ENTITIES variable safely

### DIFF
--- a/app.py
+++ b/app.py
@@ -38,7 +38,7 @@ _LOGGER = logging.getLogger(__title__)
 GITHUB_ACCESS_TOKEN = os.getenv("GITHUB_ACCESS_TOKEN")
 
 KEBECHET_ENTITIES = "PullRequest,Issue"
-MI_ENTITIES = os.environ["MI_ENTITIES"]
+MI_ENTITIES = os.getenv("MI_ENTITIES")
 
 KEBECHET_KNOWLEDGE_PATH = Path("thoth-sli-metrics").joinpath("kebechet-update-manager")
 


### PR DESCRIPTION
## Related Issues and Dependencies
Fixes #178 

## This introduces a breaking change

- [ ] Yes
- [X] No


## Description
Line `DEPLOYMENT_NAME = os.environ["THOTH_DEPLOYMENT_NAME"]` is not changed, because we want to assure that the deployment is ALWAYS specified, whereas the `MI_ENTITIES` are optional, so `None` is also sufficient value
